### PR TITLE
Add initial ERP core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # HEXERP
+
+HEXERP is a modular Enterprise Resource Planning (ERP) platform designed for UK retailers. It provides a SaaS-ready core with plug-and-play modules for features like sales and inventory. Administrators can manage customers and enable modules via a central configuration system.
+
+## Development
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the development server:
+   ```bash
+   uvicorn erp.main:app --reload
+   ```

--- a/erp/core/admin.py
+++ b/erp/core/admin.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter
+from .config import settings
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+@router.post("/customers/{customer_id}/modules/{module_name}/enable")
+def enable_customer_module(customer_id: str, module_name: str) -> dict:
+    settings.enable_module(customer_id, module_name)
+    return {"status": "enabled", "customer": customer_id, "module": module_name}
+
+
+@router.post("/customers/{customer_id}/modules/{module_name}/disable")
+def disable_customer_module(customer_id: str, module_name: str) -> dict:
+    settings.disable_module(customer_id, module_name)
+    return {"status": "disabled", "customer": customer_id, "module": module_name}

--- a/erp/core/config.py
+++ b/erp/core/config.py
@@ -1,0 +1,20 @@
+from typing import Dict
+
+
+class Settings:
+    """Application configuration settings."""
+
+    def __init__(self):
+        # Enabled modules for each customer keyed by customer ID
+        self.customer_modules: Dict[str, set[str]] = {}
+
+    def enable_module(self, customer_id: str, module_name: str) -> None:
+        modules = self.customer_modules.setdefault(customer_id, set())
+        modules.add(module_name)
+
+    def disable_module(self, customer_id: str, module_name: str) -> None:
+        modules = self.customer_modules.setdefault(customer_id, set())
+        modules.discard(module_name)
+
+
+settings = Settings()

--- a/erp/main.py
+++ b/erp/main.py
@@ -1,0 +1,22 @@
+from fastapi import FastAPI, Request
+
+from .core.admin import router as admin_router
+from .modules import load_enabled_modules
+
+app = FastAPI(title="HEXERP")
+app.include_router(admin_router)
+
+
+@app.middleware("http")
+async def add_customer_modules(request: Request, call_next):
+    customer_id = request.headers.get("X-Customer-ID")
+    if customer_id:
+        for router in load_enabled_modules(customer_id):
+            app.include_router(router)
+    response = await call_next(request)
+    return response
+
+
+@app.get("/")
+async def root() -> dict:
+    return {"message": "Welcome to HEXERP"}

--- a/erp/modules/__init__.py
+++ b/erp/modules/__init__.py
@@ -1,0 +1,10 @@
+from importlib import import_module
+from typing import Iterable
+
+from ..core.config import settings
+
+
+def load_enabled_modules(customer_id: str) -> Iterable:
+    for module_name in settings.customer_modules.get(customer_id, set()):
+        module = import_module(f"erp.modules.{module_name}.routes")
+        yield module.router

--- a/erp/modules/inventory/__init__.py
+++ b/erp/modules/inventory/__init__.py
@@ -1,0 +1,1 @@
+# Inventory module

--- a/erp/modules/inventory/routes.py
+++ b/erp/modules/inventory/routes.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/inventory", tags=["inventory"])
+
+
+@router.get("/items")
+def list_items() -> list[dict]:
+    # Placeholder implementation
+    return [{"id": 1, "name": "Sample Item"}]

--- a/erp/modules/sales/__init__.py
+++ b/erp/modules/sales/__init__.py
@@ -1,0 +1,1 @@
+# Sales module

--- a/erp/modules/sales/routes.py
+++ b/erp/modules/sales/routes.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/sales", tags=["sales"])
+
+
+@router.get("/orders")
+def list_orders() -> list[dict]:
+    # Placeholder implementation
+    return [{"id": 1, "total": 100.0}]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+SQLAlchemy
+pydantic


### PR DESCRIPTION
## Summary
- create FastAPI-based ERP skeleton
- implement admin module to enable or disable modules per customer
- add sample sales and inventory modules
- update README with project description and usage instructions
- add requirements file for dependencies

## Testing
- `python -m py_compile $(find erp -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684ea8a45b8883238c451e2803885f10