### PR TITLE
Add Vercel deployment files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ HEXERP is a modular Enterprise Resource Planning (ERP) platform designed for UK 
    ```bash
    uvicorn erp.main:app --reload
    ```
+
+## Deploying to Vercel
+
+Vercel looks for serverless functions in the `api` directory. This repository
+provides `api/index.py` which simply exports the FastAPI app so it can run as a
+serverless function. A minimal `vercel.json` is included to set the function's
+runtime options. After pushing the code to a Vercel-connected repository, the
+application will be served from `/api` and you should no longer see a 404 page.

--- a/api/index.py
+++ b/api/index.py
@@ -1,0 +1,1 @@
+from erp.main import app

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "functions": {
+    "api/index.py": { "maxDuration": 10 }
+  }
+}


### PR DESCRIPTION
## Summary
- create `api/index.py` to export the FastAPI app for Vercel
- add `vercel.json` to configure the function
- document the new Vercel deployment setup

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_684ecb8ea61c8323809e15116995c088