### PR TITLE
Fix Vercel root 404 by routing / to /api

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,8 @@
 {
   "functions": {
     "api/index.py": { "maxDuration": 10 }
-  }
+  },
+  "routes": [
+    { "src": "/", "dest": "/api" }
+  ]
 }


### PR DESCRIPTION
## Summary
- configure `vercel.json` to route the root path to `/api`

This helps avoid 404 errors on Vercel when visiting the deployment root.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684eccf8ede08323bfcbe20d6c3ce402