### PR TITLE
Fix Vercel root rewrite

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,8 @@
 {
   "functions": {
     "api/index.py": { "maxDuration": 10 }
-  }
+  },
+  "rewrites": [
+    { "source": "/", "destination": "/api" }
+  ]
 }


### PR DESCRIPTION
## Summary
- use `rewrites` to serve the API from the root path

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684eccf8ede08323bfcbe20d6c3ce402